### PR TITLE
docs: 更新标题为「ESP32 固件在线烧录工具」

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Flashy · ESP32 固件烧录工具
+# Flashy · ESP32 固件在线烧录工具
 
 [![CI](https://github.com/shenjingnan/flashy/actions/workflows/ci.yml/badge.svg)](https://github.com/shenjingnan/flashy/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Flashy —— 浏览器端 ESP32 固件烧录工具" />
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
-    <title>Flashy · ESP32 固件烧录</title>
+    <title>Flashy · ESP32 固件在线烧录工具</title>
     <link rel="stylesheet" href="/src/style.css" />
   </head>
   <body>


### PR DESCRIPTION
将 README.md 与 index.html 的标题统一更新为「Flashy · ESP32 固件在线烧录工具」，突出在线烧录特性。