### PR TITLE
feat: 内置固件弹窗支持点击条目直接选择

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -143,8 +143,8 @@ describe('main.ts 冒烟测试', () => {
     );
     await import('../main');
     const fileInput = document.getElementById('file-input') as HTMLInputElement | null;
-    const selectBtn = document.querySelector<HTMLButtonElement>('.builtin-item .btn-tiny');
-    selectBtn?.click();
+    const builtinItem = document.querySelector<HTMLElement>('.builtin-item');
+    builtinItem?.click();
     await vi.waitFor(() => {
       expect(document.getElementById('file-info')?.textContent).toContain('4 B');
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -484,6 +484,9 @@ function renderBuiltinList(): void {
   for (const firmware of BUILTIN_FIRMWARES) {
     const item = document.createElement('li');
     item.className = 'builtin-item';
+    item.addEventListener('click', () => {
+      void selectBuiltinFirmware(firmware);
+    });
 
     const meta = document.createElement('div');
     meta.className = 'builtin-meta';
@@ -498,15 +501,7 @@ function renderBuiltinList(): void {
       meta.appendChild(desc);
     }
 
-    const selectBtn = document.createElement('button');
-    selectBtn.type = 'button';
-    selectBtn.className = 'btn btn-tiny';
-    selectBtn.textContent = '选择';
-    selectBtn.addEventListener('click', () => {
-      void selectBuiltinFirmware(firmware);
-    });
-
-    item.append(meta, selectBtn);
+    item.append(meta);
     fragment.appendChild(item);
   }
   el.builtinList.replaceChildren(fragment);

--- a/src/style.css
+++ b/src/style.css
@@ -594,12 +594,21 @@ input[type="file"]::file-selector-button {
 .builtin-item {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
   padding: 10px 12px;
   border: 1px solid var(--panel-border);
   border-radius: 8px;
   background: var(--terminal-bg);
+  cursor: pointer;
+  user-select: none;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.builtin-item:hover {
+  border-color: var(--accent);
+  background-color: rgba(59, 130, 246, 0.08);
 }
 
 .builtin-meta {


### PR DESCRIPTION
## 改动背景

内置固件弹窗中，每个固件项右侧有一个独立的「选择」按钮，用户需要先定位按钮再点击，交互冗余、体验不佳。

## 改动内容

- **src/main.ts**：移除列表项右侧的「选择」按钮，改为点击整个固件条目即可直接选中（`li.builtin-item` 挂 click 事件，调用 `selectBuiltinFirmware`）
- **src/style.css**：为 `.builtin-item` 增加 `cursor: pointer`、`user-select: none` 与过渡动画，并新增 hover 高亮（边框变主题色 + 淡蓝背景），提升可点击性提示；移除不再需要的 `justify-content: space-between`
- **src/__tests__/main.test.ts**：更新冒烟测试，由点击 `.builtin-item .btn-tiny` 改为直接点击 `.builtin-item`

## 验证

- `pnpm run test`：130 个用例全部通过
- `pnpm run check`：typecheck + lint 通过
