### PR TITLE
fix(serial): 修复 CH343 开发板串口监控无日志

### DIFF
--- a/public/serial-test.html
+++ b/public/serial-test.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <title>serial-test</title>
+    <style>
+      body {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 13px;
+        margin: 0;
+        padding: 16px;
+        background: #111;
+        color: #ddd;
+      }
+      .bar {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        margin-bottom: 8px;
+        flex-wrap: wrap;
+      }
+      button {
+        font: inherit;
+        padding: 4px 10px;
+        cursor: pointer;
+        border: 1px solid #555;
+        border-radius: 4px;
+        background: #222;
+        color: #eee;
+      }
+      button:hover {
+        background: #333;
+      }
+      input {
+        font: inherit;
+        width: 360px;
+        padding: 4px 8px;
+        background: #1a1a1a;
+        color: #eee;
+        border: 1px solid #444;
+        border-radius: 4px;
+      }
+      #status {
+        color: #8bc34a;
+      }
+      #log {
+        background: #0d0d0d;
+        border: 1px solid #333;
+        border-radius: 4px;
+        padding: 8px;
+        height: 60vh;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
+      .rx {
+        color: #7ec8e3;
+      }
+      .act {
+        color: #c792ea;
+      }
+      .err {
+        color: #ff6b6b;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="bar">
+      <button type="button" id="connectBtn">连接设备</button>
+      <button type="button" id="disconnectBtn">断开</button>
+      <button type="button" id="runBtn">执行序列</button>
+      <span>序列：</span>
+      <input id="seqInput" placeholder="D1|R1|W100|D0|W50|R0|W300" />
+      <span id="status"></span>
+    </div>
+    <div id="log"></div>
+    <script>
+      'use strict';
+      const $ = (id) => document.getElementById(id);
+      const logEl = $('log');
+      const seqInput = $('seqInput');
+      let port = null;
+      let reader = null;
+      const decoder = new TextDecoder();
+      let byteCount = 0;
+      const params = new URLSearchParams(location.search);
+
+      // 默认序列：优先 ?seq=，否则候选 A（显式 DTR 翻转 + EN 释放时 IO0 高）
+      seqInput.value = params.get('seq') || 'D1|R1|W100|D0|W50|R0|W300';
+
+      function appendLine(cls, text) {
+        const line = document.createElement('div');
+        line.className = cls || '';
+        const ts = new Date().toISOString().slice(11, 23);
+        line.textContent = `[${ts}] ${text}`;
+        logEl.appendChild(line);
+        logEl.scrollTop = logEl.scrollHeight;
+      }
+      const log = (t) => appendLine('act', t);
+      const logRx = (t) => appendLine('rx', t);
+      const logErr = (t) => appendLine('err', t);
+
+      function setStatus(text) {
+        $('status').textContent = text;
+      }
+
+      async function connect() {
+        if (!('serial' in navigator)) {
+          logErr('当前浏览器不支持 Web Serial API');
+          return;
+        }
+        try {
+          // 先尝试已授权端口；没有则弹出选择器（需用户手势）
+          let p = (await navigator.serial.getPorts())[0];
+          if (!p) {
+            p = await navigator.serial.requestPort();
+          }
+          await p.open({ baudRate: 115200 });
+          port = p;
+          const info = p.getInfo ? p.getInfo() : {};
+          const vid = (info.usbVendorId ?? 0).toString(16);
+          const pid = (info.usbProductId ?? 0).toString(16);
+          setStatus(`已连接 VID=${vid} PID=${pid}`);
+          log(`已连接：VID=${vid} PID=${pid}，开始读取`);
+          startRead();
+        } catch (err) {
+          logErr(`连接失败: ${err}`);
+          setStatus(`err:${err}`);
+        }
+      }
+
+      async function startRead() {
+        if (!port?.readable) return;
+        reader = port.readable.getReader();
+        (async () => {
+          try {
+            while (true) {
+              const { value, done } = await reader.read();
+              if (done) break;
+              if (value && value.length > 0) {
+                byteCount += value.length;
+                const text = decoder.decode(value, { stream: true });
+                logRx(text.replace(/\r/g, ''));
+              }
+            }
+          } catch (err) {
+            if (!String(err).includes('cancel')) logErr(`读取中断: ${err}`);
+          }
+        })();
+      }
+
+      function parseSeq(s) {
+        return s
+          .split('|')
+          .map((part) => part.trim())
+          .filter(Boolean)
+          .map((part) => ({ code: part[0].toUpperCase(), arg: part.slice(1) }));
+      }
+
+      async function runSeq() {
+        if (!port) {
+          logErr('未连接设备，请先点「连接设备」');
+          setStatus('err:未连接');
+          return;
+        }
+        const s = seqInput.value.trim();
+        const steps = parseSeq(s);
+        log(`--- 执行序列: ${s} ---`);
+        for (const step of steps) {
+          if (step.code === 'D') {
+            await port.setSignals({ dataTerminalReady: step.arg === '1' });
+            log(`  DTR=${step.arg}`);
+          } else if (step.code === 'R') {
+            await port.setSignals({ requestToSend: step.arg === '1' });
+            log(`  RTS=${step.arg}`);
+          } else if (step.code === 'W') {
+            const ms = Number(step.arg);
+            await new Promise((r) => setTimeout(r, ms));
+            log(`  等待 ${ms}ms`);
+          } else {
+            logErr(`未知指令: ${step.code}`);
+          }
+        }
+        setStatus(`seq 完成 bytes=${byteCount}`);
+      }
+
+      $('connectBtn').addEventListener('click', connect);
+      $('runBtn').addEventListener('click', runSeq);
+      $('disconnectBtn').addEventListener('click', async () => {
+        try {
+          if (reader) {
+            await reader.cancel();
+            reader = null;
+          }
+          if (port) await port.close();
+        } catch (err) {
+          logErr(`断开失败: ${err}`);
+        }
+        port = null;
+        setStatus('已断开');
+        log('已断开');
+      });
+
+      // ?autorun=1：自动连接（仅当端口已授权）+ 执行序列 + 读取 duration ms
+      if (params.get('autorun') === '1') {
+        (async () => {
+          await connect();
+          await runSeq();
+          const dur = Number(params.get('duration') || '1500');
+          await new Promise((r) => setTimeout(r, dur));
+          const seqShort = seqInput.value.replace(/\|/g, '');
+          const ok = byteCount > 0;
+          document.title = `serial-test | ${ok ? 'ok' : 'silent'} | ${seqShort} | bytes=${byteCount}`;
+          log(ok ? `>>> 检测到 ${byteCount} 字节（序列有效）` : '>>> 未检测到数据（序列无效）');
+        })();
+      }
+    </script>
+  </body>
+</html>

--- a/src/__tests__/flashService.test.ts
+++ b/src/__tests__/flashService.test.ts
@@ -1,20 +1,20 @@
-import type { FlashOptions, IEspLoaderTerminal } from 'esptool-js';
+import type { FlashOptions, IEspLoaderTerminal, SerialOptions } from 'esptool-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
   class MockTransport {
     static instances: MockTransport[] = [];
+    /** rawRead 回调输出的数据（默认含 ROM 启动日志，用于触发启动检测）。 */
+    static rawData: Uint8Array = new TextEncoder().encode(
+      'ESP-ROM:esp32s3-20210327\r\nrst:0x15 (RTC_SW_SYS_RST)\r\nwaiting for download\r\n'
+    );
     device: SerialPort;
-    connect = vi.fn<() => Promise<void>>(async () => {});
-    setDTR = vi.fn<() => Promise<void>>(async () => {});
-    setRTS = vi.fn<() => Promise<void>>(async () => {});
+    connect = vi.fn<(baud: number, options?: SerialOptions) => Promise<void>>(async () => {});
+    setDTR = vi.fn<(state: boolean) => Promise<void>>(async () => {});
+    setRTS = vi.fn<(state: boolean) => Promise<void>>(async () => {});
     disconnect = vi.fn<() => Promise<void>>(async () => {});
     rawRead = vi.fn(async (onData: (data: Uint8Array) => void) => {
-      onData(
-        new TextEncoder().encode(
-          'ESP-ROM:esp32s3-20210327\r\nrst:0x15 (RTC_SW_SYS_RST)\r\nwaiting for download\r\n'
-        )
-      );
+      onData(MockTransport.rawData);
     });
     constructor(device: SerialPort) {
       this.device = device;
@@ -67,6 +67,9 @@ const port = {} as SerialPort;
 
 beforeEach(() => {
   mocks.MockTransport.instances.length = 0;
+  mocks.MockTransport.rawData = new TextEncoder().encode(
+    'ESP-ROM:esp32s3-20210327\r\nrst:0x15 (RTC_SW_SYS_RST)\r\nwaiting for download\r\n'
+  );
   mocks.MockESPLoader.instances.length = 0;
   mocks.MockESPLoader.mainErrorQueue = [];
   mocks.MockESPLoader.nextFlashSizeError = null;
@@ -187,10 +190,31 @@ describe('createFlashService', () => {
     const service = createFlashService(port, 115200, makeTerminal());
     await service.detect();
     await service.finish();
-    const transport = mocks.MockTransport.instances[0];
-    expect(transport?.setDTR).toHaveBeenCalled();
-    expect(transport?.setRTS).toHaveBeenCalled();
-    expect(transport?.disconnect).toHaveBeenCalledTimes(1);
+    // finish() 先断开 esploader 连接，再以新 Transport 复位到应用并检测启动日志
+    const esploaderTransport = mocks.MockTransport.instances[0];
+    const resetTransport = mocks.MockTransport.instances[1];
+    expect(resetTransport?.setDTR).toHaveBeenCalled();
+    expect(resetTransport?.setRTS).toHaveBeenCalled();
+    expect(esploaderTransport?.disconnect).toHaveBeenCalledTimes(1);
+    expect(resetTransport?.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry the reset when no boot log is detected', async () => {
+    vi.useFakeTimers();
+    try {
+      // rawRead 只产生非启动日志 → booted 恒 false → 触发全部重试
+      mocks.MockTransport.rawData = new TextEncoder().encode('nothing to see here\r\n');
+      const service = createFlashService(port, 115200, makeTerminal());
+      const monitorPromise = service.monitor({ consoleBaud: 115200, onConsoleData: vi.fn() });
+      // 3 次复位：每次 hardResetPulse(100+50+300ms) + 检测窗口(1500ms)
+      await vi.advanceTimersByTimeAsync(7000);
+      await monitorPromise;
+      const t = mocks.MockTransport.instances[0];
+      // hardResetPulse 每次调用 setRTS(true) 与 setRTS(false)，3 次共 6 次
+      expect(t?.setRTS.mock.calls.length).toBe(6);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('should reset the device and start console monitoring via physical pulse', async () => {
@@ -244,6 +268,26 @@ describe('createFlashService', () => {
     expect(onConsoleData).toHaveBeenCalledWith(expect.stringContaining('ESP-ROM'));
     // 监控期间保持连接
     expect(monitorTransport?.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('should open the serial port with flowControl none for monitoring', async () => {
+    const service = createFlashService(port, 115200, makeTerminal());
+    await service.monitor({ consoleBaud: 115200, onConsoleData: vi.fn() });
+    const monitorTransport = mocks.MockTransport.instances[0];
+    expect(monitorTransport?.connect).toHaveBeenCalledWith(115200, { flowControl: 'none' });
+  });
+
+  it('should apply the DTR+RTS reset pulse in order and read before resetting', async () => {
+    const service = createFlashService(port, 115200, makeTerminal());
+    await service.monitor({ consoleBaud: 115200, onConsoleData: vi.fn() });
+    const t = mocks.MockTransport.instances[0];
+    // 复位序列：显式 DTR true → RTS true → DTR false → RTS false（兼容 CH343）
+    expect(t?.setDTR.mock.calls.map((c) => c[0])).toEqual([true, false]);
+    expect(t?.setRTS.mock.calls.map((c) => c[0])).toEqual([true, false]);
+    // 先启动读循环，再执行复位脉冲（rawRead 早于首次 setRTS）
+    const rawReadOrder = t?.rawRead.mock.invocationCallOrder[0] ?? 0;
+    const rtsOrder = t?.setRTS.mock.invocationCallOrder[0] ?? 0;
+    expect(rawReadOrder).toBeLessThan(rtsOrder);
   });
 
   it('should stop the serial monitor on abort', async () => {

--- a/src/serial/flashService.ts
+++ b/src/serial/flashService.ts
@@ -6,6 +6,23 @@ import type { BaudRate, BaudSelection, DetectResult, ProgressInfo } from '../cor
 /** 无法检测 Flash 大小时使用的兜底值（足够大以避免误拒绝合法固件）。 */
 const FALLBACK_FLASH_SIZE = '64MB';
 
+/** 物理复位脉冲时序（毫秒）：EN 低保持 / DTR 释放后稳定 / EN 释放后等待芯片启动。 */
+const RESET_HOLD_MS = 100;
+const DTR_SETTLE_MS = 50;
+const RESET_RELEASE_MS = 300;
+
+/** 复位重试次数：CH343 等桥接芯片经 Web Serial 控制线传递存在偶发失败，重试提高成功率。 */
+const RESET_RETRY = 3;
+/** 每次复位后等待启动日志检测的时长（毫秒）。 */
+const BOOT_DETECT_MS = 1500;
+/** ROM 启动日志特征（复位成功即打印，如 rst:0x / boot:0x / ESP-ROM / ets）。 */
+const BOOT_LOG_RE = /rst:0x|boot:0x|ESP-ROM|ets /;
+
+/** 判断一段串口文本是否为复位后的 ROM 启动日志。 */
+function isBootLog(text: string): boolean {
+  return BOOT_LOG_RE.test(text);
+}
+
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /** 烧录请求参数。 */
@@ -145,38 +162,54 @@ export function createFlashService(
   }
 
   /**
-   * 物理复位脉冲：GPIO0 拉高 → 正常启动固件；EN 拉低再拉高 → 复位芯片（等效 RST 键）。
-   * 与 esptool-js ClassicReset 的 RTS→EN 复位机制一致（本板已验证 RTS→EN 有效）。
+   * 物理复位脉冲：显式翻转 DTR 制造控制线状态变化，EN 低保持一段时间，
+   * 释放 DTR（GPIO0 拉高 → 正常启动），再释放 EN 复位芯片（等效 RST 键）。
+   *
+   * 相比纯 RTS 脉冲（仅 EN 动作），此序列在复位期间显式翻转 DTR，兼容 CH343 等
+   * 桥接芯片经 Web Serial 传递控制线时的差异（实测纯 RTS 脉冲在 CH343 上无法把
+   * 芯片复位到应用，芯片停在下载模式；DTR+RTS 组合在烧录路径上已验证有效）。
+   * 与 esptool-js ClassicReset 的 DTR+RTS 复位机制一致（本板已验证 RTS→EN 有效）。
    */
-  async function resetPulse(t: Transport): Promise<void> {
+  async function hardResetPulse(t: Transport): Promise<void> {
     try {
-      await t.setDTR(false); // GPIO0 高 → 正常启动
+      await t.setDTR(true); // GPIO0 低（制造 DTR 状态变化）
       await t.setRTS(true); // EN 低 → 芯片复位
-      await sleep(200);
+      await sleep(RESET_HOLD_MS);
+      await t.setDTR(false); // GPIO0 高 → 正常启动
+      await sleep(DTR_SETTLE_MS); // 等 GPIO0 稳定为高
       await t.setRTS(false); // EN 高 → 芯片启动
-      await sleep(300);
+      await sleep(RESET_RELEASE_MS); // 等芯片输出启动日志
     } catch {
       // 复位失败不影响后续流程
     }
   }
 
   async function finish(): Promise<void> {
-    if (transport !== undefined) {
-      // 复位芯片运行新固件（物理 RTS 脉冲，不依赖 esptool-js 的假复位）
-      await resetPulse(transport);
-      await transport.disconnect().catch(() => {});
+    try {
+      // 烧录后以新连接复位到应用并检测启动日志，
+      // 规避 CH343 上复位偶发失败导致新固件不自动运行的问题
+      await connectAndResetToApp(115200, () => {});
+    } catch {
+      // 复位失败不影响后续流程
     }
+    await transport?.disconnect().catch(() => {});
     transport = undefined;
     esploader = undefined;
   }
 
   /**
-   * 复位设备（等效按下开发板 RST 键）并保持串口打开，持续读取开发板日志。
-   * 不使用 esptool-js 的 after('hard_reset')——其 HardReset 只执行 setRTS(false)，
-   * 不产生复位脉冲，属于"假复位"。
-   * 监控会持续运行，直到调用 abort() 断开串口。
+   * 复位芯片到应用并持续监控输出。
+   *
+   * 断开旧连接后重新打开串口，先启动读循环再执行复位脉冲；
+   * 复位可能偶发失败（CH343 等桥接芯片经 Web Serial 控制线传递不稳定），
+   * 与 esptool-js 一致采用"复位 + 检测启动日志"重试，直到检测到 ROM 启动日志。
+   *
+   * @returns 是否在重试窗口内检测到启动日志（未检测到也可能已复位成功）。
    */
-  async function reset(options: ResetOptions): Promise<void> {
+  async function connectAndResetToApp(
+    consoleBaud: number,
+    onConsoleData: (text: string) => void
+  ): Promise<boolean> {
     if (transport !== undefined) {
       await transport.disconnect().catch(() => {});
       transport = undefined;
@@ -184,60 +217,55 @@ export function createFlashService(
     }
     const t = new Transport(port, true);
     transport = t;
+    let booted = false;
     try {
-      await t.connect(options.consoleBaud);
-      await resetPulse(t);
-      // 持续读取开发板串口输出，解码后回调；由 abort() 断开时终止
+      await t.connect(consoleBaud, { flowControl: 'none' });
+      // 先启动读循环再复位：保证复位后的启动日志被实时读到，避免依赖驱动侧缓冲
       const decoder = new TextDecoder();
       void t
         .rawRead(
           (data: Uint8Array) => {
-            options.onConsoleData(decoder.decode(data, { stream: true }));
+            const text = decoder.decode(data, { stream: true });
+            if (!booted && isBootLog(text)) {
+              booted = true;
+            }
+            onConsoleData(text);
           },
           () => false
         )
         .catch(() => {});
+      for (let i = 0; i < RESET_RETRY; i++) {
+        await hardResetPulse(t);
+        const deadline = Date.now() + BOOT_DETECT_MS;
+        while (Date.now() < deadline && !booted) {
+          await sleep(100);
+        }
+        if (booted) {
+          break;
+        }
+      }
     } catch (err) {
       transport = undefined;
       await t.disconnect().catch(() => {});
       throw err;
     }
+    return booted;
+  }
+
+  async function reset(options: ResetOptions): Promise<void> {
+    await connectAndResetToApp(options.consoleBaud, options.onConsoleData);
   }
 
   /** 串口监控：复位设备（等效 RST 键）后持续读取开发板输出。 */
   async function monitor(options: MonitorOptions): Promise<void> {
-    if (transport !== undefined) {
-      await transport.disconnect().catch(() => {});
-      transport = undefined;
-      esploader = undefined;
-    }
-    const t = new Transport(port, true);
-    transport = t;
-    try {
-      await t.connect(options.consoleBaud);
-      await resetPulse(t);
-      // 持续读取开发板串口输出，解码后回调；由 abort() 断开时终止
-      const decoder = new TextDecoder();
-      void t
-        .rawRead(
-          (data: Uint8Array) => {
-            options.onConsoleData(decoder.decode(data, { stream: true }));
-          },
-          () => false
-        )
-        .catch(() => {});
-    } catch (err) {
-      transport = undefined;
-      await t.disconnect().catch(() => {});
-      throw err;
-    }
+    await connectAndResetToApp(options.consoleBaud, options.onConsoleData);
   }
 
   async function abort(): Promise<void> {
     if (transport !== undefined) {
       if (esploader !== undefined) {
         // 烧录失败路径：先复位清除残留的 stub
-        await resetPulse(transport);
+        await hardResetPulse(transport);
       }
       // 监控会话直接断开即可终止 rawRead
       await transport.disconnect().catch(() => {});


### PR DESCRIPTION
## 问题

CH343 开发板上串口监控无日志（FT232 正常）。根因：浏览器 Web Serial `setSignals` 传递 DTR/RTS 控制线在 CH343 上存在**偶发失败**，Flashy 原复位（纯 RTS 脉冲、单次不重试）在失败时无法把芯片复位到应用，芯片停在下载模式静默；烧录能成功是因为 esptool-js 连接时会多次重试复位。

## 修复

- 复位序列改为显式 DTR+RTS 脉冲（释放 EN 前先确认 GPIO0 拉高）
- 复位后检测 ROM 启动日志（rst:/boot:/ESP-ROM），失败自动重试 3 次
- 监控/复位先启动读循环再复位，消除读侧时序依赖
- 烧录完成（finish）改用新连接复位到应用并检测启动日志
- 打开串口显式指定 flowControl: none

## 验证

- typecheck / lint / 133 个单测全部通过
- CH343 真机验证：复位序列有效（boot:0x8 应用启动），读取路径正常