### PR TITLE
feat(log): 日志视图虚拟滚动，容量提升至 10 万条

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,15 @@
             </div>
           </div>
         </div>
+        <button
+          id="scroll-bottom-btn"
+          type="button"
+          class="btn btn-tiny scroll-bottom-btn"
+          hidden
+          title="回到底部"
+        >
+          ⬇ 回到底部
+        </button>
       </section>
     </main>
 

--- a/src/__tests__/logExport.test.ts
+++ b/src/__tests__/logExport.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { formatLogEntry } from '../core/logBuffer';
+import { formatLogTail, hasTailText } from '../core/logExport';
+import type { LogEntry } from '../core/types';
+
+function entry(text: string): LogEntry {
+  return { level: 'info', type: 'system', text, ts: 0 };
+}
+
+const lines: readonly LogEntry[] = [entry('a'), entry('bb'), entry('ccc')];
+
+describe('formatLogTail', () => {
+  it('should return empty result for empty input', () => {
+    expect(formatLogTail([])).toEqual({ text: '', startLine: 0, lineCount: 0 });
+  });
+
+  it('should format all lines when no options are given', () => {
+    const result = formatLogTail(lines);
+    expect(result.startLine).toBe(0);
+    expect(result.lineCount).toBe(3);
+    expect(result.text).toBe(lines.map(formatLogEntry).join('\n'));
+  });
+
+  it('should take only the last maxLines lines', () => {
+    const result = formatLogTail(lines, { maxLines: 2 });
+    expect(result.startLine).toBe(1);
+    expect(result.lineCount).toBe(2);
+    expect(result.text).toBe(lines.slice(1).map(formatLogEntry).join('\n'));
+  });
+
+  it('should accumulate from the tail up to maxChars', () => {
+    // 每条格式化长度 = 20 + text.length，换行 +1；maxChars 只保证覆盖到该字符数
+    const result = formatLogTail(lines, { maxChars: 20 });
+    expect(result.lineCount).toBe(1);
+    expect(result.startLine).toBe(2);
+    expect(result.text).toBe(lines.slice(2).map(formatLogEntry).join('\n'));
+  });
+
+  it('should prefer maxChars over maxLines when both are given', () => {
+    const result = formatLogTail(lines, { maxLines: 2, maxChars: 20 });
+    expect(result.lineCount).toBe(1); // maxChars 优先，只取最后 1 行
+  });
+
+  it('should not exceed the buffer length', () => {
+    const result = formatLogTail(lines, { maxLines: 99 });
+    expect(result.startLine).toBe(0);
+    expect(result.lineCount).toBe(3);
+  });
+});
+
+describe('hasTailText', () => {
+  it('should find a needle in the tail', () => {
+    expect(hasTailText(lines, 'ccc', 100)).toBe(true);
+  });
+
+  it('should respect the maxLines scan window', () => {
+    expect(hasTailText(lines, 'a', 1)).toBe(false); // 'a' 在窗口外
+    expect(hasTailText(lines, 'a', 100)).toBe(true);
+  });
+
+  it('should return false when the needle is absent', () => {
+    expect(hasTailText(lines, 'zzz', 100)).toBe(false);
+  });
+
+  it('should return false for an empty input', () => {
+    expect(hasTailText([], 'x', 5)).toBe(false);
+  });
+});

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -153,4 +153,166 @@ describe('main.ts 冒烟测试', () => {
     expect((document.getElementById('address-input') as HTMLInputElement).value).toBe('0x0');
     expect(fileInput?.value).toBe('');
   });
+
+  it('should hide the scroll-bottom button initially', async () => {
+    await import('../main');
+    const btn = document.getElementById('scroll-bottom-btn') as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    expect(btn.hidden).toBe(true);
+  });
+
+  it('should toggle the scroll-bottom button as the user scrolls away from and back to bottom', async () => {
+    await import('../main');
+    const logView = document.getElementById('log-view') as HTMLPreElement;
+    const btn = document.getElementById('scroll-bottom-btn') as HTMLButtonElement;
+    // happy-dom 的 scrollHeight/clientHeight 恒为 0 且只读，需在实例上盖影子属性模拟滚动
+    Object.defineProperty(logView, 'scrollHeight', {
+      configurable: true,
+      writable: true,
+      value: 1000,
+    });
+    Object.defineProperty(logView, 'clientHeight', {
+      configurable: true,
+      writable: true,
+      value: 400,
+    });
+    logView.scrollTop = 0; // 视口顶部，远离底部
+    logView.dispatchEvent(new Event('scroll'));
+    expect(btn.hidden).toBe(false); // 离开底部 → 显示
+
+    logView.scrollTop = 600; // 回到底部（剩余可滚 0 < 24）
+    logView.dispatchEvent(new Event('scroll'));
+    expect(btn.hidden).toBe(true); // 回到底部 → 隐藏
+  });
+
+  it('should scroll to bottom and hide the button when clicked', async () => {
+    await import('../main');
+    const logView = document.getElementById('log-view') as HTMLPreElement;
+    const btn = document.getElementById('scroll-bottom-btn') as HTMLButtonElement;
+    Object.defineProperty(logView, 'scrollHeight', {
+      configurable: true,
+      writable: true,
+      value: 1000,
+    });
+    Object.defineProperty(logView, 'clientHeight', {
+      configurable: true,
+      writable: true,
+      value: 400,
+    });
+    logView.scrollTop = 0;
+    logView.dispatchEvent(new Event('scroll'));
+    expect(btn.hidden).toBe(false);
+    btn.click();
+    expect(btn.hidden).toBe(true);
+    expect(logView.scrollTop).toBe(1000);
+  });
+
+  it('should append new log lines without rebuilding existing nodes', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response(new Uint8Array([0xde, 0xad, 0xbe, 0xef]).buffer)))
+    );
+    const main = await import('../main');
+    main.__setMeasureRowHeightForTests(() => 20);
+    const logView = document.getElementById('log-view') as HTMLPreElement;
+    Object.defineProperty(logView, 'clientHeight', {
+      configurable: true,
+      writable: true,
+      value: 2000,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50)); // 等待初始防抖渲染
+    const firstNode = logView.querySelector('.log-line');
+    expect(firstNode).not.toBeNull();
+    document.querySelector<HTMLElement>('.builtin-item')?.click();
+    await vi.waitFor(() => {
+      expect(logView.querySelectorAll('.log-line').length).toBeGreaterThanOrEqual(2);
+    });
+    // 首个节点引用不变，证明是复用节点增量追加而非重建
+    expect(logView.querySelector('.log-line')).toBe(firstNode);
+  });
+
+  it('should clear the log view when the clear button is clicked', async () => {
+    await import('../main');
+    await new Promise((resolve) => setTimeout(resolve, 50)); // 等待初始防抖渲染
+    const logView = document.getElementById('log-view') as HTMLPreElement;
+    expect(logView.querySelectorAll('.log-line').length).toBeGreaterThanOrEqual(1);
+    document.getElementById('clear-log-btn')?.click();
+    await new Promise((resolve) => setTimeout(resolve, 50)); // 等待防抖渲染
+    expect(logView.querySelectorAll('.log-line').length).toBe(0);
+  });
+
+  it('should create the virtual scroll container', async () => {
+    await import('../main');
+    const logView = document.getElementById('log-view');
+    expect(logView?.querySelector('.log-virtual')).not.toBeNull();
+  });
+
+  it('should only render a limited window of rows when logs are many', async () => {
+    const main = await import('../main');
+    main.__setMeasureRowHeightForTests(() => 20);
+    const logView = document.getElementById('log-view') as HTMLPreElement;
+    Object.defineProperty(logView, 'clientHeight', {
+      configurable: true,
+      writable: true,
+      value: 200,
+    });
+    const buffer = main.__getLogBufferForTests();
+    for (let i = 0; i < 500; i++) {
+      buffer.push('info', `line ${i}`, 'device');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 60)); // 等待防抖 + rAF
+    const rows = logView.querySelectorAll('.log-row').length;
+    expect(rows).toBeGreaterThan(0);
+    expect(rows).toBeLessThanOrEqual(30); // 可见 10 行 + 2×5 overscan + 余量
+  });
+
+  it('should render different rows after scrolling', async () => {
+    const main = await import('../main');
+    main.__setMeasureRowHeightForTests(() => 20);
+    const logView = document.getElementById('log-view') as HTMLPreElement;
+    Object.defineProperty(logView, 'clientHeight', {
+      configurable: true,
+      writable: true,
+      value: 200,
+    });
+    const logVirtual = logView.querySelector('.log-virtual') as HTMLElement;
+    Object.defineProperty(logView, 'scrollHeight', {
+      configurable: true,
+      get: () => parseFloat(logVirtual.style.height) || 0,
+    });
+    const buffer = main.__getLogBufferForTests();
+    for (let i = 0; i < 500; i++) {
+      buffer.push('info', `line ${i}`, 'device');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(logView.querySelector('.log-row')?.getAttribute('data-index')).toBe('0');
+    logView.scrollTop = 400; // 约第 20 行位置
+    logView.dispatchEvent(new Event('scroll'));
+    await new Promise((resolve) => setTimeout(resolve, 20)); // 冲 rAF
+    const after = Number(logView.querySelector('.log-row')?.getAttribute('data-index') ?? '0');
+    expect(after).toBeGreaterThan(10);
+  });
+
+  it('should keep scrolling to bottom while the user stays at the bottom', async () => {
+    const main = await import('../main');
+    main.__setMeasureRowHeightForTests(() => 20);
+    const logView = document.getElementById('log-view') as HTMLPreElement;
+    Object.defineProperty(logView, 'clientHeight', {
+      configurable: true,
+      writable: true,
+      value: 200,
+    });
+    const logVirtual = logView.querySelector('.log-virtual') as HTMLElement;
+    Object.defineProperty(logView, 'scrollHeight', {
+      configurable: true,
+      get: () => parseFloat(logVirtual.style.height) || 0,
+    });
+    const buffer = main.__getLogBufferForTests();
+    buffer.push('info', 'first', 'device');
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    buffer.push('info', 'second', 'device');
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(logView.scrollTop).toBe(logView.scrollHeight);
+    expect(logView.textContent).toContain('second');
+  });
 });

--- a/src/__tests__/scrollUtils.test.ts
+++ b/src/__tests__/scrollUtils.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { isNearBottom, planLogRender } from '../core/scrollUtils';
+import type { LogEntry } from '../core/types';
+
+function entry(text: string): LogEntry {
+  return { level: 'info', type: 'system', text, ts: 0 };
+}
+
+describe('isNearBottom', () => {
+  it('should return true when remaining scroll distance is below the threshold', () => {
+    expect(isNearBottom(1000, 600, 400)).toBe(true); // 剩余 0 < 24
+    expect(isNearBottom(1000, 585, 400)).toBe(true); // 剩余 15 < 24
+  });
+
+  it('should return false when scrolled away from the bottom', () => {
+    expect(isNearBottom(1000, 0, 400)).toBe(false); // 剩余 600 >= 24
+    expect(isNearBottom(1000, 400, 400)).toBe(false); // 剩余 200 >= 24
+  });
+
+  it('should honor a custom threshold and the exact boundary', () => {
+    expect(isNearBottom(1000, 600, 400, 0)).toBe(false); // 剩余 0 < 0 不成立
+    expect(isNearBottom(1000, 590, 400, 10)).toBe(false); // 剩余 10 < 10 不成立（边界恰等）
+    expect(isNearBottom(1000, 600, 400, 10)).toBe(true); // 剩余 0 < 10
+  });
+
+  it('should return true when content does not fill the viewport', () => {
+    expect(isNearBottom(300, 0, 400)).toBe(true); // 剩余为负，视为已在底部
+  });
+});
+
+describe('planLogRender', () => {
+  it('should return clear when there are no lines', () => {
+    expect(planLogRender({ renderedEntries: [entry('a')] }, [])).toEqual({ action: 'clear' });
+  });
+
+  it('should return rebuild on the first render', () => {
+    const lines = [entry('a'), entry('b')];
+    expect(planLogRender({ renderedEntries: null }, lines)).toEqual({ action: 'rebuild' });
+  });
+
+  it('should return rebuild when the current first line is not in the previous snapshot', () => {
+    // 一次性裁剪过多：lines[0] 不在已渲染快照中，无法增量对齐 → 全量重建兜底
+    const prev = [entry('a'), entry('b'), entry('c')];
+    const lines = [entry('x'), entry('y')];
+    expect(planLogRender({ renderedEntries: prev }, lines)).toEqual({ action: 'rebuild' });
+  });
+
+  it('should return rebuild when the total count shrank unexpectedly', () => {
+    const first = entry('a');
+    const prev = [first, entry('b'), entry('c'), entry('d')];
+    const lines = [first, entry('b')]; // 整体变少
+    expect(planLogRender({ renderedEntries: prev }, lines)).toEqual({ action: 'rebuild' });
+  });
+
+  it('should return adjust with append only when lines were added without eviction', () => {
+    const first = entry('a');
+    const prev = [first];
+    const lines = [first, entry('b'), entry('c')];
+    expect(planLogRender({ renderedEntries: prev }, lines)).toEqual({
+      action: 'adjust',
+      removeFromHead: 0,
+      appendFrom: 1,
+      to: 3,
+    });
+  });
+
+  it('should return adjust that removes evicted head lines and appends the new tail', () => {
+    const a = entry('a');
+    const b = entry('b');
+    const c = entry('c');
+    const d = entry('d');
+    const e = entry('e');
+    const prev = [a, b, c, d];
+    const lines = [b, c, d, e]; // 裁掉 a，追加 e
+    expect(planLogRender({ renderedEntries: prev }, lines)).toEqual({
+      action: 'adjust',
+      removeFromHead: 1,
+      appendFrom: 3,
+      to: 4,
+    });
+  });
+
+  it('should return adjust that only removes when the head shrank without addition', () => {
+    const a = entry('a');
+    const b = entry('b');
+    const c = entry('c');
+    const prev = [a, b, c];
+    const lines = [b, c]; // 裁掉 a，无新增
+    expect(planLogRender({ renderedEntries: prev }, lines)).toEqual({
+      action: 'adjust',
+      removeFromHead: 1,
+      appendFrom: 2,
+      to: 2,
+    });
+  });
+
+  it('should return noop when nothing changed', () => {
+    const first = entry('a');
+    const lines = [first];
+    expect(planLogRender({ renderedEntries: lines }, lines)).toEqual({ action: 'noop' });
+  });
+});

--- a/src/__tests__/virtualLog.test.ts
+++ b/src/__tests__/virtualLog.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendHeights,
+  applyMeasurements,
+  correctHeight,
+  createVirtualLogState,
+  rowAtOffset,
+  rowTop,
+  trimHead,
+  unionWithSelection,
+  visibleRange,
+} from '../core/virtualLog';
+
+describe('createVirtualLogState', () => {
+  it('should initialize an empty state', () => {
+    const s = createVirtualLogState(20);
+    expect(s.heights).toEqual([]);
+    expect(s.offsets).toEqual([0]);
+    expect(s.totalHeight).toBe(0);
+    expect(s.defaultHeight).toBe(20);
+  });
+});
+
+describe('appendHeights', () => {
+  it('should append estimated heights and keep offsets as prefix sums', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 3);
+    expect(s.heights).toEqual([20, 20, 20]);
+    expect(s.offsets).toEqual([0, 20, 40, 60]);
+    expect(s.totalHeight).toBe(60);
+  });
+});
+
+describe('rowAtOffset', () => {
+  it('should locate the row containing a given offset', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 3); // offsets [0,20,40,60]
+    expect(rowAtOffset(s, 0)).toBe(0);
+    expect(rowAtOffset(s, 19)).toBe(0);
+    expect(rowAtOffset(s, 20)).toBe(1);
+    expect(rowAtOffset(s, 39)).toBe(1);
+    expect(rowAtOffset(s, 40)).toBe(2);
+    expect(rowAtOffset(s, 60)).toBe(2); // 恰等于 totalHeight → 末行
+    expect(rowAtOffset(s, 100)).toBe(2); // 越界 → 末行
+  });
+
+  it('should return 0 for an empty state', () => {
+    expect(rowAtOffset(createVirtualLogState(20), 10)).toBe(0);
+  });
+});
+
+describe('visibleRange', () => {
+  it('should compute the visible window and apply overscan', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 10);
+    expect(visibleRange(s, 0, 100, 0)).toEqual({ start: 0, end: 5 }); // 100px 覆盖第 0-5 行
+    expect(visibleRange(s, 0, 100, 1)).toEqual({ start: 0, end: 6 });
+  });
+
+  it('should clamp to the first and last rows', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 10);
+    expect(visibleRange(s, 0, 100, 5)).toEqual({ start: 0, end: 9 });
+    expect(visibleRange(s, 100, 100, 0)).toEqual({ start: 5, end: 9 });
+  });
+
+  it('should return an empty range for an empty state', () => {
+    expect(visibleRange(createVirtualLogState(20), 0, 100, 0)).toEqual({ start: 0, end: -1 });
+  });
+});
+
+describe('trimHead', () => {
+  it('should remove k rows from the head and return the removed height', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 5);
+    expect(trimHead(s, 2)).toBe(40);
+    expect(s.heights).toEqual([20, 20, 20]);
+    expect(s.offsets).toEqual([0, 20, 40, 60]);
+    expect(s.totalHeight).toBe(60);
+  });
+
+  it('should return 0 for k <= 0', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 3);
+    expect(trimHead(s, 0)).toBe(0);
+    expect(s.totalHeight).toBe(60);
+  });
+
+  it('should clear everything when k >= length', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 3);
+    expect(trimHead(s, 5)).toBe(0);
+    expect(s.heights).toEqual([]);
+    expect(s.offsets).toEqual([0]);
+    expect(s.totalHeight).toBe(0);
+  });
+});
+
+describe('applyMeasurements', () => {
+  it('should apply a single measurement and propagate offsets', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 3); // offsets [0,20,40,60], total 60
+    expect(applyMeasurements(s, [{ index: 0, height: 30 }])).toBe(10);
+    expect(s.heights[0]).toBe(30);
+    expect(s.offsets).toEqual([0, 30, 50, 70]);
+    expect(s.totalHeight).toBe(70);
+  });
+
+  it('should handle multiple measurements in arbitrary order', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 4); // offsets [0,20,40,60,80], total 80
+    applyMeasurements(s, [
+      { index: 2, height: 25 }, // +5
+      { index: 0, height: 15 }, // -5
+    ]);
+    expect(s.heights).toEqual([15, 20, 25, 20]);
+    expect(s.offsets).toEqual([0, 15, 35, 60, 80]);
+    expect(s.totalHeight).toBe(80);
+  });
+
+  it('should return 0 when nothing changed', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 2);
+    expect(applyMeasurements(s, [{ index: 0, height: 20 }])).toBe(0);
+    expect(applyMeasurements(s, [])).toBe(0);
+  });
+
+  it('should propagate consecutive measurements correctly', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 4); // offsets [0,20,40,60,80], total 80
+    applyMeasurements(s, [
+      { index: 0, height: 10 }, // -10
+      { index: 1, height: 30 }, // +10
+      { index: 2, height: 20 }, // 无变化
+    ]);
+    expect(s.heights).toEqual([10, 30, 20, 20]);
+    expect(s.offsets).toEqual([0, 10, 40, 60, 80]);
+    expect(s.totalHeight).toBe(80);
+  });
+});
+
+describe('correctHeight', () => {
+  it('should correct a single row height', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 2); // offsets [0,20,40], total 40
+    expect(correctHeight(s, 1, 40)).toBe(20);
+    expect(s.heights).toEqual([20, 40]);
+    expect(s.offsets).toEqual([0, 20, 60]);
+    expect(s.totalHeight).toBe(60);
+  });
+});
+
+describe('rowTop', () => {
+  it('should return the top offset of a row', () => {
+    const s = createVirtualLogState(20);
+    appendHeights(s, 3);
+    expect(rowTop(s, 0)).toBe(0);
+    expect(rowTop(s, 2)).toBe(40);
+    expect(rowTop(s, 99)).toBe(0); // 越界兜底
+  });
+});
+
+describe('unionWithSelection', () => {
+  it('should merge visible and selection windows when within cap', () => {
+    expect(unionWithSelection({ start: 10, end: 20 }, { start: 0, end: 30 }, 100)).toEqual({
+      start: 0,
+      end: 30,
+    });
+  });
+
+  it('should accept a union exactly at cap', () => {
+    expect(unionWithSelection({ start: 10, end: 20 }, { start: 0, end: 30 }, 31)).toEqual({
+      start: 0,
+      end: 30,
+    });
+  });
+
+  it('should fall back to the visible window when the union exceeds cap', () => {
+    expect(unionWithSelection({ start: 10, end: 20 }, { start: 0, end: 30 }, 15)).toEqual({
+      start: 10,
+      end: 20,
+    });
+  });
+});

--- a/src/core/logExport.ts
+++ b/src/core/logExport.ts
@@ -1,0 +1,70 @@
+import { formatLogEntry } from './logBuffer';
+import type { LogEntry } from './types';
+
+/** 日志尾部导出选项。 */
+export interface LogTailOptions {
+  /** 只取末尾最多 maxLines 行（与 maxChars 二选一）。 */
+  maxLines?: number;
+  /** 从末尾累积到至少 maxChars 字符（与 maxLines 二选一）。 */
+  maxChars?: number;
+}
+
+/** 日志尾部导出的结果。 */
+export interface LogTailResult {
+  /** 拼接后的文本（行间以换行分隔）。 */
+  text: string;
+  /** 起始行号（相对于 lines）。 */
+  startLine: number;
+  /** 实际导出的行数。 */
+  lineCount: number;
+}
+
+/**
+ * 惰性取日志尾部：只格式化需要的行，避免对 10 万行全量 join 造成卡顿。
+ *
+ * 传 maxChars 时从末尾向前累积字符数（含换行），达到上限即停，保证至少能覆盖该字符数；
+ * 传 maxLines 时固定取末尾 maxLines 行。两者都传时 maxChars 优先。
+ */
+export function formatLogTail(
+  lines: readonly LogEntry[],
+  options: LogTailOptions = {}
+): LogTailResult {
+  const { maxLines, maxChars } = options;
+  let startLine = 0;
+  if (maxChars !== undefined) {
+    let chars = 0;
+    startLine = lines.length;
+    while (startLine > 0 && chars < maxChars) {
+      startLine -= 1;
+      const entry = lines[startLine];
+      if (entry !== undefined) {
+        chars += formatLogEntry(entry).length + 1;
+      }
+    }
+  } else if (maxLines !== undefined && lines.length > maxLines) {
+    startLine = lines.length - maxLines;
+  }
+  const parts: string[] = [];
+  for (let i = startLine; i < lines.length; i++) {
+    const entry = lines[i];
+    if (entry !== undefined) {
+      parts.push(formatLogEntry(entry));
+    }
+  }
+  return { text: parts.join('\n'), startLine, lineCount: lines.length - startLine };
+}
+
+/**
+ * 从尾部扫描是否包含指定文本，最多看 maxLines 行。
+ * 用于 isStaleStubUsed 这类只需关注最近日志的检查，避免 O(全量)。
+ */
+export function hasTailText(lines: readonly LogEntry[], needle: string, maxLines: number): boolean {
+  const start = Math.max(0, lines.length - maxLines);
+  for (let i = start; i < lines.length; i++) {
+    const entry = lines[i];
+    if (entry?.text.includes(needle)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/core/scrollUtils.ts
+++ b/src/core/scrollUtils.ts
@@ -1,0 +1,57 @@
+import type { LogEntry } from './types';
+
+/** 判断滚动位置是否已接近底部（剩余可滚距离小于阈值）。 */
+export function isNearBottom(
+  scrollHeight: number,
+  scrollTop: number,
+  clientHeight: number,
+  threshold = 24
+): boolean {
+  return scrollHeight - scrollTop - clientHeight < threshold;
+}
+
+/** 日志视图渲染计划：决定本次渲染是清空、全量重建、增量调整还是无需操作。 */
+export type LogRenderPlan =
+  | { action: 'clear' }
+  | { action: 'rebuild' }
+  | { action: 'adjust'; removeFromHead: number; appendFrom: number; to: number }
+  | { action: 'noop' };
+
+/** 上次已渲染状态（供渲染决策使用）。 */
+export interface LogRenderState {
+  /** 上次渲染时的完整日志快照；null 表示尚未渲染。 */
+  renderedEntries: readonly LogEntry[] | null;
+}
+
+/**
+ * 根据已渲染状态与当前日志快照，规划本次渲染动作。
+ *
+ * 依赖前提：logBuffer.push 总是新建 entry 对象、环形裁剪用 slice 保留幸存者引用，
+ * 因此幸存的 entry 引用保持不变，可用引用对齐检测头部被裁掉的条数。
+ */
+export function planLogRender(prev: LogRenderState, lines: readonly LogEntry[]): LogRenderPlan {
+  const first = lines[0];
+  if (lines.length === 0 || first === undefined) {
+    return { action: 'clear' };
+  }
+  const prevEntries = prev.renderedEntries;
+  if (prevEntries === null) {
+    return { action: 'rebuild' }; // 首次渲染：全量重建
+  }
+  // 当前首条在已渲染快照中的索引 = 头部被环形缓冲裁掉的条数（幸存者保持相对顺序）
+  const headTrimmed = prevEntries.indexOf(first);
+  if (headTrimmed === -1) {
+    // 当前首条不在已渲染快照中（一次性裁剪过多）→ 全量重建兜底
+    return { action: 'rebuild' };
+  }
+  // 已渲染且幸存的条数 = prevEntries.length - headTrimmed；其后为本次新追加的条目
+  const appendFrom = prevEntries.length - headTrimmed;
+  if (appendFrom > lines.length) {
+    // 条目整体变少（异常）→ 全量重建兜底
+    return { action: 'rebuild' };
+  }
+  if (headTrimmed === 0 && appendFrom === lines.length) {
+    return { action: 'noop' };
+  }
+  return { action: 'adjust', removeFromHead: headTrimmed, appendFrom, to: lines.length };
+}

--- a/src/core/virtualLog.ts
+++ b/src/core/virtualLog.ts
@@ -1,0 +1,170 @@
+/**
+ * 虚拟滚动的纯逻辑层：管理每行高度与前缀和偏移，负责行定位、窗口计算与增量更新。
+ *
+ * 不依赖 DOM，便于 node 环境单测。DOM 渲染层只消费 visibleRange / rowTop 等结果。
+ */
+
+/** 虚拟列表状态：heights 与 lines 等长，offsets 为前缀和。 */
+export interface VirtualLogState {
+  /** 每行高度：已测量行为实测值，未测量行为 defaultHeight。 */
+  heights: number[];
+  /** 前缀和：offsets[i] = Σ heights[0..i)，offsets[n] = totalHeight。 */
+  offsets: number[];
+  /** 总内容高度（即占位容器应设置的高度）。 */
+  totalHeight: number;
+  /** 未测量行的预估高度（像素）。 */
+  defaultHeight: number;
+}
+
+/** 一次行高测量结果。 */
+export interface RowMeasurement {
+  index: number;
+  height: number;
+}
+
+/** 行号区间（闭区间）。 */
+export interface WindowRange {
+  start: number;
+  end: number;
+}
+
+/** 创建空的虚拟列表状态。 */
+export function createVirtualLogState(defaultHeight: number): VirtualLogState {
+  return { heights: [], offsets: [0], totalHeight: 0, defaultHeight };
+}
+
+/** 追加 count 行预估高度；O(count)。 */
+export function appendHeights(state: VirtualLogState, count: number): void {
+  for (let i = 0; i < count; i++) {
+    state.totalHeight += state.defaultHeight; // 先累加，再写入前缀和，保证 offsets 末位 = totalHeight
+    state.offsets.push(state.totalHeight);
+    state.heights.push(state.defaultHeight);
+  }
+}
+
+/** 从头部裁掉 k 行，返回被裁掉的像素高度（供调用方补偿滚动位置）；k 批量化一次 O(n)。 */
+export function trimHead(state: VirtualLogState, k: number): number {
+  if (k <= 0) {
+    return 0;
+  }
+  if (k >= state.heights.length) {
+    state.heights.length = 0;
+    state.offsets.length = 1;
+    state.offsets[0] = 0;
+    state.totalHeight = 0;
+    return 0;
+  }
+  const removed = state.offsets[k] ?? 0;
+  state.heights.splice(0, k);
+  const newLen = state.offsets.length - k;
+  for (let i = 0; i < newLen; i++) {
+    state.offsets[i] = (state.offsets[i + k] ?? 0) - removed;
+  }
+  state.offsets.length = newLen;
+  state.totalHeight = state.offsets[newLen - 1] ?? 0;
+  return removed;
+}
+
+/** 二分定位：给定内容坐标 y，返回 y 所在的行号；y 越界时收敛到边界行。 */
+export function rowAtOffset(state: VirtualLogState, y: number): number {
+  const n = state.heights.length;
+  if (n === 0) {
+    return 0;
+  }
+  const o = state.offsets;
+  let lo = 0;
+  let hi = n; // o[hi] = totalHeight
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if ((o[mid] ?? 0) <= y) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return Math.min(lo, n - 1);
+}
+
+/** 计算可见行窗口：覆盖 [y, y + viewportHeight] 并外扩 overscan 行。 */
+export function visibleRange(
+  state: VirtualLogState,
+  y: number,
+  viewportHeight: number,
+  overscan: number
+): WindowRange {
+  const n = state.heights.length;
+  if (n === 0) {
+    return { start: 0, end: -1 };
+  }
+  const start = Math.max(0, rowAtOffset(state, y) - overscan);
+  const end = Math.min(
+    n - 1,
+    rowAtOffset(state, Math.min(y + viewportHeight, state.totalHeight)) + overscan
+  );
+  return { start, end };
+}
+
+/** 行的 top 偏移。 */
+export function rowTop(state: VirtualLogState, index: number): number {
+  return state.offsets[index] ?? 0;
+}
+
+/**
+ * 批量校正行高：更新 heights 并增量传播 offsets 到尾部，返回 totalHeight 增量。
+ * 单次 O(n - minIndex)；measurements 为空或全部无变化时返回 0。
+ */
+export function applyMeasurements(
+  state: VirtualLogState,
+  measurements: readonly RowMeasurement[]
+): number {
+  if (measurements.length === 0) {
+    return 0;
+  }
+  let minIndex = Number.POSITIVE_INFINITY;
+  const deltas = new Map<number, number>();
+  for (const m of measurements) {
+    const old = state.heights[m.index] ?? 0;
+    const delta = m.height - old;
+    if (delta === 0) {
+      continue;
+    }
+    deltas.set(m.index, delta);
+    state.heights[m.index] = m.height;
+    if (m.index < minIndex) {
+      minIndex = m.index;
+    }
+  }
+  if (deltas.size === 0) {
+    return 0;
+  }
+  const keys = [...deltas.keys()].sort((a, b) => a - b);
+  let cumulative = 0;
+  let p = 0;
+  for (let i = minIndex + 1; i < state.offsets.length; i++) {
+    while (p < keys.length && (keys[p] ?? Number.POSITIVE_INFINITY) < i) {
+      cumulative += deltas.get(keys[p] ?? 0) ?? 0;
+      p += 1;
+    }
+    state.offsets[i] = (state.offsets[i] ?? 0) + cumulative;
+  }
+  state.totalHeight += cumulative;
+  return cumulative;
+}
+
+/** 校正单行高度（复用 applyMeasurements）。 */
+export function correctHeight(state: VirtualLogState, index: number, measured: number): number {
+  return applyMeasurements(state, [{ index, height: measured }]);
+}
+
+/**
+ * 将可见窗口与选区窗口合并为渲染窗口，总长不超过 cap；超限时优先保留可见窗口。
+ */
+export function unionWithSelection(vis: WindowRange, sel: WindowRange, cap: number): WindowRange {
+  const min = Math.min(vis.start, sel.start);
+  const max = Math.max(vis.end, sel.end);
+  if (max - min + 1 <= cap) {
+    return { start: min, end: max };
+  }
+  // 选区扩展超过 cap：退回可见窗口，保证用户正在看的内容完整渲染
+  return vis;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,10 +20,23 @@ import {
   loadBuiltinFirmware,
 } from './core/builtinFirmwares';
 import { parseEspIdfLevel } from './core/espIdfLog';
-import { createLogBuffer, formatBytes, formatLogEntry } from './core/logBuffer';
+import { createLogBuffer, formatBytes, formatLogEntry, type LogBuffer } from './core/logBuffer';
+import { formatLogTail, hasTailText } from './core/logExport';
 import { selectionTextInside } from './core/logSelection';
+import { isNearBottom, planLogRender } from './core/scrollUtils';
 import { createFlashStateMachine } from './core/stateMachine';
-import type { BaudRate, DetectResult } from './core/types';
+import type { BaudRate, DetectResult, LogEntry } from './core/types';
+import {
+  appendHeights,
+  applyMeasurements,
+  createVirtualLogState,
+  type RowMeasurement,
+  rowTop,
+  trimHead,
+  unionWithSelection,
+  visibleRange,
+  type WindowRange,
+} from './core/virtualLog';
 import type { FlashService } from './serial/flashService';
 import { createFlashService } from './serial/flashService';
 import { isWebSerialSupported, requestSerialPort } from './serial/portManager';
@@ -61,6 +74,7 @@ interface Elements {
   copyLogBtn: HTMLButtonElement | null;
   askAiLogBtn: HTMLButtonElement | null;
   askAiLogMenu: HTMLElement | null;
+  scrollBottomBtn: HTMLButtonElement | null;
 }
 
 function byId(id: string): HTMLElement | null {
@@ -99,13 +113,45 @@ function loadElements(): Elements {
     copyLogBtn: byId('copy-log-btn') as HTMLButtonElement | null,
     askAiLogBtn: byId('ask-ai-log-btn') as HTMLButtonElement | null,
     askAiLogMenu: byId('ask-ai-log-menu'),
+    scrollBottomBtn: byId('scroll-bottom-btn') as HTMLButtonElement | null,
   };
 }
 
 const el = loadElements();
 const machine = createFlashStateMachine();
-const logBuffer = createLogBuffer({ max: 500 });
+const logBuffer = createLogBuffer({ max: 100000 });
 const terminal = createLoaderTerminal(logBuffer);
+
+/** 距日志底部多少像素视为已到底部（自动回底触发阈值）。 */
+const SCROLL_NEAR_BOTTOM_THRESHOLD = 24;
+/** 用户是否停留在日志底部：在底部时新日志自动回底，离开后保持视点不动。 */
+let stickToBottom = true;
+/** 已渲染到日志视图的完整日志快照；null 表示尚未渲染（用于增量对齐）。 */
+let renderedEntries: readonly LogEntry[] | null = null;
+
+// ---- 虚拟滚动参数与状态 ----
+/** 可见窗口外上下各多渲染的行数（缓冲快速滚动）。 */
+const LOG_VIRTUAL_OVERSCAN = 5;
+/** 选区跨屏时渲染窗口的最大行数上限。 */
+const MAX_SELECTION_ROWS = 5000;
+/** 「复制」最多导出的行数（日志过多时只复制最近 N 行）。 */
+const COPY_MAX_LINES = 10000;
+/** 残留 stub 检测只扫描的最近行数。 */
+const LOG_TAIL_SCAN = 2000;
+/** 未测量行的预估行高（12.5px × 1.6 行高）。 */
+const DEFAULT_ROW_HEIGHT = 20;
+
+const virtualState = createVirtualLogState(DEFAULT_ROW_HEIGHT);
+/** entry → 行节点映射：复用节点对象，保证滚动重渲染后选区锚点存活。 */
+const rowNodes = new Map<LogEntry, HTMLDivElement>();
+/** 虚拟滚动占位容器（.log-virtual）。 */
+let logVirtual: HTMLDivElement | null = null;
+/** 选区覆盖的行号区间；null 表示无选区。 */
+let selectionRows: WindowRange | null = null;
+/** scroll 事件 rAF 节流 id。 */
+let scrollRafId: number | undefined;
+/** 行高测量函数（测试可注入，happy-dom 的 offsetHeight 恒为 0）。 */
+let measureRowHeight: (row: HTMLElement) => number = (row) => row.offsetHeight;
 
 /** 当前已选择的固件数据。 */
 let firmwareData: Uint8Array | null = null;
@@ -164,21 +210,200 @@ if (!isWebSerialSupported()) {
   }
 }
 
-// ---- 日志渲染（烧录操作 + 开发板输出合并，防抖渲染）----
+// ---- 日志渲染（烧录操作 + 开发板输出合并，防抖 + 增量渲染）----
+/** 构造一条日志的 DOM 节点（虚拟滚动行）。 */
+function buildLogNode(entry: LogEntry): HTMLDivElement {
+  const node = document.createElement('div');
+  node.textContent = formatLogEntry(entry);
+  node.className = `log-row log-line log-${entry.level} log-${entry.type}`;
+  return node;
+}
+
+// 虚拟滚动占位容器：撑起滚动高度，行节点在其中绝对定位
+if (el.logView !== null) {
+  logVirtual = document.createElement('div');
+  logVirtual.className = 'log-virtual';
+  el.logView.appendChild(logVirtual);
+}
+
+/** 定位选区端点到行号；不在行内返回 null。 */
+function rowIndexOf(node: Node | null): number | null {
+  let current = node instanceof Element ? node : (node?.parentElement ?? null);
+  while (current !== null && current !== el.logView) {
+    if (current.classList.contains('log-row')) {
+      const index = Number((current as HTMLElement).dataset.index);
+      return Number.isFinite(index) ? index : null;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+/** 渲染当前可见窗口（含选区扩展范围）：复用节点对象、只移动不重建。 */
+function renderWindow(): void {
+  if (el.logView === null || logVirtual === null) {
+    return;
+  }
+  const lines = logBuffer.lines();
+  const n = lines.length;
+  if (n === 0) {
+    return;
+  }
+  const vis = visibleRange(
+    virtualState,
+    el.logView.scrollTop,
+    el.logView.clientHeight,
+    LOG_VIRTUAL_OVERSCAN
+  );
+  let start = vis.start;
+  let end = vis.end;
+  if (selectionRows !== null) {
+    const merged = unionWithSelection(vis, selectionRows, MAX_SELECTION_ROWS);
+    start = merged.start;
+    end = merged.end;
+  }
+  // 移除窗口外的节点
+  for (const [entry, node] of rowNodes) {
+    const index = Number(node.dataset.index ?? '0');
+    if (index < start || index > end) {
+      node.remove();
+      rowNodes.delete(entry);
+    }
+  }
+  // 增量创建缺失节点并保持 DOM 升序插入。
+  // 关键：不移动窗口内已存在的节点，避免选区锚点脱离文档导致浏览器重置选区（拖动选择错乱）。
+  const fresh: Array<{ node: HTMLDivElement; index: number }> = [];
+  for (let i = start; i <= end && i < n; i++) {
+    const entry = lines[i];
+    if (entry === undefined || rowNodes.has(entry)) {
+      continue;
+    }
+    const node = buildLogNode(entry);
+    rowNodes.set(entry, node);
+    node.dataset.index = String(i);
+    node.style.top = `${rowTop(virtualState, i)}px`;
+    fresh.push({ node, index: i });
+  }
+  if (fresh.length > 0) {
+    // absolute 定位不影响视觉，但选区文本顺序依赖 DOM 升序，故按 data-index 找插入位置
+    const children = logVirtual.children;
+    for (const item of fresh) {
+      let insertBefore: Element | null = null;
+      for (const child of children) {
+        if (Number((child as HTMLElement).dataset.index ?? '0') > item.index) {
+          insertBefore = child;
+          break;
+        }
+      }
+      logVirtual.insertBefore(item.node, insertBefore);
+    }
+  }
+  // 测量新增节点并校正行高
+  const measurements: RowMeasurement[] = [];
+  for (const item of fresh) {
+    measurements.push({ index: item.index, height: Math.max(1, measureRowHeight(item.node)) });
+  }
+  applyMeasurements(virtualState, measurements);
+  // 校正后按最新偏移重定位窗口内节点（仅改 top，不移动节点）
+  for (const node of rowNodes.values()) {
+    const index = Number(node.dataset.index ?? '0');
+    if (index >= start && index <= end) {
+      node.style.top = `${rowTop(virtualState, index)}px`;
+    }
+  }
+  // 更新占位高度（scrollHeight 依赖它），回底时滚动到底
+  logVirtual.style.height = `${virtualState.totalHeight}px`;
+  if (stickToBottom) {
+    el.logView.scrollTop = el.logView.scrollHeight;
+  }
+}
+
+/** 按渲染计划更新虚拟列表；用户离开底部时保持视点不动。 */
 function renderLogView(): void {
   if (el.logView === null) {
     return;
   }
   const lines = logBuffer.lines();
-  const fragment = document.createDocumentFragment();
-  for (const entry of lines) {
-    const node = document.createElement('div');
-    node.textContent = formatLogEntry(entry);
-    node.className = `log-line log-${entry.level} log-${entry.type}`;
-    fragment.appendChild(node);
+  const plan = planLogRender({ renderedEntries }, lines);
+
+  if (plan.action === 'clear') {
+    for (const node of rowNodes.values()) {
+      node.remove();
+    }
+    rowNodes.clear();
+    logVirtual?.replaceChildren();
+    virtualState.heights.length = 0;
+    virtualState.offsets.length = 1;
+    virtualState.offsets[0] = 0;
+    virtualState.totalHeight = 0;
+    if (logVirtual !== null) {
+      logVirtual.style.height = '0px';
+    }
+    renderedEntries = null;
+    stickToBottom = true;
+    selectionRows = null;
+  } else if (plan.action === 'rebuild') {
+    // 首次渲染或异常兜底：重建高度数组（DOM 只有可见行，重建便宜）
+    for (const node of rowNodes.values()) {
+      node.remove();
+    }
+    rowNodes.clear();
+    virtualState.heights.length = 0;
+    virtualState.offsets.length = 1;
+    virtualState.offsets[0] = 0;
+    virtualState.totalHeight = 0;
+    appendHeights(virtualState, lines.length);
+    renderedEntries = lines;
+    renderWindow();
+  } else if (plan.action === 'adjust') {
+    // 环形缓冲裁掉头部：裁剪高度并平移已渲染节点行号，再追加新行高度
+    const removed = trimHead(virtualState, plan.removeFromHead);
+    for (const node of rowNodes.values()) {
+      node.dataset.index = String(Number(node.dataset.index ?? '0') - plan.removeFromHead);
+    }
+    appendHeights(virtualState, plan.to - plan.appendFrom);
+    renderedEntries = lines;
+    if (selectionRows !== null) {
+      const s = selectionRows.start - plan.removeFromHead;
+      const e = selectionRows.end - plan.removeFromHead;
+      selectionRows = e < 0 ? null : { start: Math.max(0, s), end: Math.max(0, e) };
+    }
+    if (!stickToBottom) {
+      el.logView.scrollTop = Math.max(0, el.logView.scrollTop - removed);
+    }
+    renderWindow();
   }
-  el.logView.replaceChildren(fragment);
-  el.logView.scrollTop = el.logView.scrollHeight;
+  // noop：日志无变化，不触碰 DOM 与滚动位置
+  updateScrollBottomButton();
+}
+
+/** 刷新「回到底部」按钮显隐：在底部隐藏，离开底部显示。 */
+function updateScrollBottomButton(): void {
+  if (el.scrollBottomBtn === null) {
+    return;
+  }
+  el.scrollBottomBtn.hidden = stickToBottom;
+}
+
+/** 滚动事件：重算用户是否停留在日志底部，并 rAF 节流重渲染窗口。 */
+function onLogScroll(): void {
+  if (el.logView === null) {
+    return;
+  }
+  stickToBottom = isNearBottom(
+    el.logView.scrollHeight,
+    el.logView.scrollTop,
+    el.logView.clientHeight,
+    SCROLL_NEAR_BOTTOM_THRESHOLD
+  );
+  updateScrollBottomButton();
+  if (scrollRafId !== undefined) {
+    return;
+  }
+  scrollRafId = requestAnimationFrame(() => {
+    scrollRafId = undefined;
+    renderWindow();
+  });
 }
 
 let logRenderTimer: number | undefined;
@@ -190,6 +415,20 @@ logBuffer.subscribe(() => {
     logRenderTimer = undefined;
     renderLogView();
   }, 30);
+});
+
+el.logView?.addEventListener('scroll', onLogScroll);
+el.scrollBottomBtn?.addEventListener('click', () => {
+  stickToBottom = true;
+  if (el.logView !== null) {
+    el.logView.scrollTop = el.logView.scrollHeight; // 瞬时跳转，程序赋值触发 scroll 事件，逻辑闭环
+  }
+  updateScrollBottomButton();
+});
+
+// 容器尺寸变化（窗口缩放/布局改变）时重渲染窗口
+window.addEventListener('resize', () => {
+  renderWindow();
 });
 
 el.clearLogBtn?.addEventListener('click', () => {
@@ -213,22 +452,34 @@ function appendConsoleLine(text: string): void {
 }
 
 // ---- 复制 / 问 AI ----
-function flashLogText(): string {
-  return logBuffer.lines().map(formatLogEntry).join('\n');
+/** 「复制」文本：日志过多时只取最近 N 行，并在开头提示已截取。 */
+function copyLogText(): string {
+  const lines = logBuffer.lines();
+  const { text, lineCount } = formatLogTail(lines, { maxLines: COPY_MAX_LINES });
+  if (lineCount < lines.length) {
+    return `…（日志过长，已复制最近 ${lineCount} 行）…\n${text}`;
+  }
+  return text;
+}
+
+/** 「问 AI」文本：只取日志末尾足够字符数，避免对 10 万行全量 join。 */
+function askAiLogText(): string {
+  return formatLogTail(logBuffer.lines(), { maxChars: ASK_AI_MAX_CHARS }).text;
 }
 
 interface LogActionsOptions {
   copyBtn: HTMLButtonElement | null;
   askBtn: HTMLButtonElement | null;
   menu: HTMLElement | null;
-  getLogText: () => string;
+  getCopyText: () => string;
+  getAskText: () => string;
   logType: string;
 }
 
 /** 为一个日志面板装配「复制」与「问 AI」下拉。 */
 function setupLogActions(options: LogActionsOptions): void {
   options.copyBtn?.addEventListener('click', async () => {
-    const text = options.getLogText();
+    const text = options.getCopyText();
     if (text === '') {
       return;
     }
@@ -264,7 +515,7 @@ function setupLogActions(options: LogActionsOptions): void {
     if (provider === undefined) {
       return;
     }
-    const logContent = truncateLog(options.getLogText(), ASK_AI_MAX_CHARS);
+    const logContent = truncateLog(options.getAskText(), ASK_AI_MAX_CHARS);
     const context = buildDeviceContext(detectResult, options.logType, consoleBaud);
     const prompt = buildAskAiPrompt(context, logContent);
     window.open(buildAskAiUrl(provider, prompt), '_blank', 'noopener');
@@ -278,7 +529,8 @@ setupLogActions({
   copyBtn: el.copyLogBtn,
   askBtn: el.askAiLogBtn,
   menu: el.askAiLogMenu,
-  getLogText: flashLogText,
+  getCopyText: copyLogText,
+  getAskText: askAiLogText,
   logType: '日志',
 });
 
@@ -305,12 +557,31 @@ let pointerPos: { x: number; y: number } | null = null;
 const SELECTION_TOOLBAR_EST_WIDTH = 150;
 
 function updateSelectionToolbar(): void {
-  const text = selectionTextInside(window.getSelection(), el.logView);
+  const sel = window.getSelection();
+  const text = selectionTextInside(sel, el.logView);
   if (text === '' || el.selectionToolbar === null) {
+    if (selectionRows !== null) {
+      selectionRows = null;
+      renderWindow();
+    }
     hideSelectionToolbar();
     return;
   }
-  const range = window.getSelection()?.getRangeAt(0);
+  // 扩展渲染窗口覆盖跨屏选区，保证选区文本完整可读
+  const a = sel !== null ? rowIndexOf(sel.anchorNode) : null;
+  const b = sel !== null ? rowIndexOf(sel.focusNode) : null;
+  const next = a !== null && b !== null ? { start: Math.min(a, b), end: Math.max(a, b) } : null;
+  if (
+    next !== null &&
+    (selectionRows === null || next.start !== selectionRows.start || next.end !== selectionRows.end)
+  ) {
+    selectionRows = next;
+    renderWindow();
+  } else if (next === null && selectionRows !== null) {
+    selectionRows = null;
+    renderWindow();
+  }
+  const range = sel?.getRangeAt(0);
   const rect = range?.getBoundingClientRect();
   if (pointerPos !== null) {
     // 贴近鼠标：右下偏移，且不超出视口
@@ -395,7 +666,7 @@ function canFlash(): boolean {
 
 /** 判断本次连接是否复用了残留的软件加载器（stub），可能导致烧录失败。 */
 function isStaleStubUsed(): boolean {
-  return logBuffer.lines().some((entry) => entry.text.includes('Stub is already running'));
+  return hasTailText(logBuffer.lines(), 'Stub is already running', LOG_TAIL_SCAN);
 }
 
 function setProgressVisible(visible: boolean): void {
@@ -795,3 +1066,13 @@ el.resetDeviceBtn?.addEventListener('click', async () => {
 
 renderUi();
 logBuffer.push('info', 'Flashy 已就绪，请连接设备并选择固件开始烧录');
+
+/** 测试钩子（main.ts 在 coverage.exclude 中）：暴露日志缓冲供冒烟测试写入。 */
+export function __getLogBufferForTests(): LogBuffer {
+  return logBuffer;
+}
+
+/** 测试钩子：注入行高测量函数（happy-dom 的 offsetHeight 恒为 0）。 */
+export function __setMeasureRowHeightForTests(fn: (row: HTMLElement) => number): void {
+  measureRowHeight = fn;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -368,6 +368,7 @@ input[type="file"]::file-selector-button {
   border: 1px solid var(--panel-border);
   border-radius: 10px;
   overflow: hidden;
+  position: relative; /* 供「回到底部」浮动按钮 absolute 定位 */
 }
 
 .terminal-header {
@@ -464,6 +465,41 @@ input[type="file"]::file-selector-button {
   color: var(--text);
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+/* 虚拟滚动：占位容器撑起滚动高度，行节点在其中绝对定位 */
+.log-virtual {
+  position: relative;
+  width: 100%;
+}
+
+.log-row {
+  position: absolute;
+  left: 0;
+  right: 0;
+  /* 字体/换行等样式由 .log-view(pre) 继承 */
+}
+
+/* 「回到底部」浮动按钮：仅当用户离开日志底部时显示 */
+.scroll-bottom-btn {
+  position: absolute;
+  right: 14px;
+  bottom: 14px;
+  z-index: 25; /* 低于 .selection-toolbar(30)，避免遮挡选区工具栏 */
+  background: var(--panel);
+  border-radius: 999px;
+  padding: 6px 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+}
+
+.scroll-bottom-btn:hover {
+  border-color: var(--text-dim);
+  color: var(--text);
+}
+
+/* 必须显式声明，否则作者样式优先级会覆盖 UA 的 [hidden]{display:none} */
+.scroll-bottom-btn[hidden] {
+  display: none;
 }
 
 .console-baud-label {


### PR DESCRIPTION
## 背景

日志视图原为 500 条环形缓冲 + 全量 DOM 渲染，长时间串口监控时日志量受限且滚动卡顿。

## 改动

- **虚拟滚动**：数据层保留 10 万条，DOM 只渲染可见行（约 20 行），滚动流畅，原生滚动条比例正确
- **滚动体验**：离开日志底部后停止强制回底、视点保持；新增「⬇ 回到底部」浮动按钮，点击回底恢复自动跟随
- **选区**：支持跨屏选中日志（渲染窗口自动扩展覆盖选区）；渲染窗口增量增删节点，修复拖动选择被重置为「向上全选」的问题
- **导出**：「复制」只取最近 1 万行并加截取提示；「问 AI」只取末尾足够字符，避免 10 万行全量拼接卡顿
- **修复**：环形缓冲裁剪由全量重建改为增量调整，修复日志达到容量上限后视口持续漂移的问题

## 测试

- 183 个测试全部通过（新增 `virtualLog` / `logExport` 单测与 main 冒烟用例）
- typecheck / lint / 覆盖率通过（`virtualLog`/`logExport` 语句与行覆盖 100%）